### PR TITLE
Fix product save reset bug

### DIFF
--- a/server/lib/supabase.ts
+++ b/server/lib/supabase.ts
@@ -240,11 +240,6 @@ export const productDb = {
       console.log("Using in-memory storage. Looking for product ID:", id);
       const index = fallbackProducts.findIndex((p) => p.id === id);
       if (index === -1) {
-        // If product is not found due to race condition, return the closest match without throwing
-        const existing = fallbackProducts[0];
-        if (existing) {
-          return existing;
-        }
         throw new Error("Product not found");
       }
       fallbackProducts[index] = {
@@ -279,10 +274,6 @@ export const productDb = {
         );
         const index = fallbackProducts.findIndex((p) => p.id === id);
         if (index === -1) {
-          const existing = fallbackProducts[0];
-          if (existing) {
-            return existing;
-          }
           throw new Error("Product not found");
         }
         fallbackProducts[index] = {
@@ -298,10 +289,6 @@ export const productDb = {
       console.warn("Supabase connection failed, using in-memory storage");
       const index = fallbackProducts.findIndex((p) => p.id === id);
       if (index === -1) {
-        const existing = fallbackProducts[0];
-        if (existing) {
-          return existing;
-        }
         throw new Error("Product not found");
       }
       fallbackProducts[index] = {


### PR DESCRIPTION
Fix product update resetting to 'Wireless' by removing incorrect fallback logic in local dev server's in-memory storage.

The local dev server's `productDb.update` function incorrectly returned the first product from its in-memory list (often "Wireless Bluetooth Headphones") when an update was attempted for a product ID that was not found. This led to the UI displaying the "Wireless" product after saving an edited product, effectively resetting the user's changes. The fix ensures that a "Product not found" error is correctly thrown, preventing this silent data corruption.

---
<a href="https://cursor.com/background-agent?bcId=bc-e938e9c8-1ea7-4985-be43-e4a1917e97b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e938e9c8-1ea7-4985-be43-e4a1917e97b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

